### PR TITLE
Bugfix/fix ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12, 3.13, 3.14]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: [3.10, 3.11, 3.12, 3.13, 3.14]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.10, 3.11, 3.12, 3.13, 3.14]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-pytest==6.0.2
-pytest-flake8==1.0.6
-xmltodict==0.12.0
+pytest==9.0.3
+pytest-flake8==1.3.0
+xmltodict==1.0.4

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
+import xml.etree.ElementTree as etree
 
 import xmltodict
 
 from markdown import Markdown
-from markdown.util import etree
 
 from mdx_variables import VariablesExtension, VariablePattern, makeExtension
 


### PR DESCRIPTION
This updates the github actions to work again

* Updated python versions tested
* Switched to xml.extree.ElementTree as markdown no longer imports that uncoditionally
* Updated github actions to latest versions to silence github complaints
* Updated test tool versions to support updated python versions

This also adresses #6, due to the need to update pytest anywyay.